### PR TITLE
Xenial base + Mono 4.4.2.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,5 @@ RUN apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \
 	&& apt-get update \
 	&& apt-get install -y mono-devel ca-certificates-mono fsharp mono-vbnc nuget dotnet-dev-1.0.0-preview2-003121 \
 	&& rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/share/dotnet/shared/Microsoft.NETCore.App/1.0.0/libuv.so /usr/lib/libuv.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:trusty-scm
+FROM buildpack-deps:xenial-scm
 
 RUN apt-get update \
 	&& apt-get install -y apt-transport-https \
@@ -6,7 +6,7 @@ RUN apt-get update \
 
 RUN apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-	&& echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list \
+	&& echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ xenial main" > /etc/apt/sources.list.d/dotnetdev.list \
     && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.2.3.4 main" > /etc/apt/sources.list.d/mono-xamarin.list \
 	&& apt-get update \
 	&& apt-get install -y mono-devel ca-certificates-mono fsharp mono-vbnc nuget dotnet-dev-1.0.0-preview2-003121 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
 RUN apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
 	&& echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ xenial main" > /etc/apt/sources.list.d/dotnetdev.list \
-    && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.2.3.4 main" > /etc/apt/sources.list.d/mono-xamarin.list \
+    && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.4.2.11 main" > /etc/apt/sources.list.d/mono-xamarin.list \
 	&& apt-get update \
 	&& apt-get install -y mono-devel ca-certificates-mono fsharp mono-vbnc nuget dotnet-dev-1.0.0-preview2-003121 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM buildpack-deps:xenial-scm
 
+# Reduce package restore sizes + times
+ENV NUGET_XMLDOC_MODE skip
+
 RUN apt-get update \
 	&& apt-get install -y apt-transport-https \
 	&& rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \
 	&& apt-get install -y mono-devel ca-certificates-mono fsharp mono-vbnc nuget dotnet-dev-1.0.0-preview2-003121 \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /usr/share/dotnet/shared/Microsoft.NETCore.App/1.0.0/libuv.so /usr/lib/libuv.so
+RUN ln -s /usr/share/dotnet/shared/Microsoft.NETCore.App/1.0.0/System.Native.so /usr/lib/libSystem.Native.so

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ Reasoning for this:
 
 ## What's not
 
-- NodeJS and therefore gulp or bower. If you need these, use [cl0sey/dotnet-mono-node-docker](https://github.com/CL0SeY/dotnet-mono-node-docker).
-- An example app! See [cl0sey/dotnet-mono-rc2-aspnet-example](https://github.com/CL0SeY/dotnet-mono-rc2-aspnet-example) instead. (needs updating for xenial / RTM / mono 4.4)
+- NodeJS and therefore bower. If you need these, use [cl0sey/dotnet-mono-node-docker](https://github.com/CL0SeY/dotnet-mono-node-docker).
+- An example app! See [CL0SeY/dotnet-mono-aspnet-core-example](https://github.com/CL0SeY/dotnet-mono-aspnet-core-example) instead.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Reasoning for this:
 ## What's included
 
 - dotnet cli (1.0.0-preview2-003121) and therefore the dotnet runtime (RTM)
-- Mono (version 4.2.3.4)
+- Mono (version 4.4.2.11)
 
 ## What's not
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This docker image intends to fill this gap.
 
 ## Base operating system
 
-The base operating system is Ubuntu 14.04.
+The base operating system is Ubuntu 16.04.
 
 Reasoning for this:
 - Attempts were made to inherit from [microsoft/dotnet](https://hub.docker.com/r/microsoft/aspnet), and install mono (i.e. on Debian Wheezy). The mono apt-get install was not supported on Wheezy.
 - Installing dotnet on Debian Jessie (i.e. inheriting from [library/mono](https://hub.docker.com/r/library/mono)) caused a lot of issues with out-of-date packages.
-- The dotnet install process for Ubuntu 14.04 is [very straightforward](https://www.microsoft.com/net/core#ubuntu).
+- The dotnet install process for Ubuntu 16.04 is [very straightforward](https://www.microsoft.com/net/core#ubuntu).
 
 ## What's included
 
@@ -25,4 +25,4 @@ Reasoning for this:
 ## What's not
 
 - NodeJS and therefore gulp or bower. If you need these, use [cl0sey/dotnet-mono-node-docker](https://github.com/CL0SeY/dotnet-mono-node-docker).
-- An example app! See [cl0sey/dotnet-mono-rc2-aspnet-example](https://github.com/CL0SeY/dotnet-mono-rc2-aspnet-example) instead.
+- An example app! See [cl0sey/dotnet-mono-rc2-aspnet-example](https://github.com/CL0SeY/dotnet-mono-rc2-aspnet-example) instead. (needs updating for xenial / RTM / mono 4.4)


### PR DESCRIPTION
Updated the base OS + Mono version.

Attempted to inherit from either microsoft/dotnet or library/mono but still experienced issues.

@seiggy you might be interested in testing?
