### PR TITLE
Use microsoft/dotnet as libjpeg62 is added for debian compat.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM microsoft/dotnet:1.0.0-preview2-sdk
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
 	&& echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
-    && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.4.2.11 main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
-	&& apt-get update
-RUN apt-get install -y mono-devel \
+	&& echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.4.2.11 main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
+	&& apt-get update \
+	&& apt-get install -y mono-devel \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN ln -s /usr/share/dotnet/shared/Microsoft.NETCore.App/1.0.0/System.Native.so /usr/lib/libSystem.Native.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM buildpack-deps:trusty-scm
+FROM microsoft/dotnet:1.0.0-preview2-sdk
 
-RUN apt-get update \
-	&& apt-get install -y apt-transport-https \
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+	&& echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
+    && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.4.2.11 main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list \
+	&& apt-get update
+RUN apt-get install -y mono-devel \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893 \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-	&& echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list \
-    && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.2.3.4 main" > /etc/apt/sources.list.d/mono-xamarin.list \
-	&& apt-get update \
-	&& apt-get install -y mono-devel ca-certificates-mono fsharp mono-vbnc nuget dotnet-dev-1.0.0-preview2-003121 \
-	&& rm -rf /var/lib/apt/lists/*
+RUN ln -s /usr/share/dotnet/shared/Microsoft.NETCore.App/1.0.0/System.Native.so /usr/lib/libSystem.Native.so

--- a/README.md
+++ b/README.md
@@ -10,19 +10,14 @@ This docker image intends to fill this gap.
 
 ## Base operating system
 
-The base operating system is Ubuntu 14.04.
-
-Reasoning for this:
-- Attempts were made to inherit from [microsoft/dotnet](https://hub.docker.com/r/microsoft/aspnet), and install mono (i.e. on Debian Wheezy). The mono apt-get install was not supported on Wheezy.
-- Installing dotnet on Debian Jessie (i.e. inheriting from [library/mono](https://hub.docker.com/r/library/mono)) caused a lot of issues with out-of-date packages.
-- The dotnet install process for Ubuntu 14.04 is [very straightforward](https://www.microsoft.com/net/core#ubuntu).
+The base operating system is Debian 8 (Jessie) due to importing from [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet)
 
 ## What's included
 
-- dotnet cli (1.0.0-preview2-003121) and therefore the dotnet runtime (RTM)
-- Mono (version 4.2.3.4)
+- dotnet sdk/cli preview2 and therefore the dotnet runtime (RTM)
+- Mono (version 4.4.2.11)
 
 ## What's not
 
-- NodeJS and therefore gulp or bower. If you need these, use [cl0sey/dotnet-mono-node-docker](https://github.com/CL0SeY/dotnet-mono-node-docker).
-- An example app! See [cl0sey/dotnet-mono-rc2-aspnet-example](https://github.com/CL0SeY/dotnet-mono-rc2-aspnet-example) instead.
+- NodeJS and therefore bower. If you need these, use [cl0sey/dotnet-mono-node-docker](https://github.com/CL0SeY/dotnet-mono-node-docker).
+- An example app! See [cl0sey/dotnet-mono-aspnet-core-example](https://github.com/CL0SeY/dotnet-mono-aspnet-core-example) instead.


### PR DESCRIPTION
Reduce a bunch of tech debt by inheriting from the microsoft/dotnet image. Turns out it was pretty easy fix the libjpeg62 dependency.

@seiggy can you try this one instead. Cheers.
